### PR TITLE
Require cython + pyrex to allow Shrapnel to be install via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,6 @@ setup (
     packages=['coro'],
     package_dir = {'': 'coroutine', 'coro': 'coro'},
     py_modules = ['backdoor', 'coro_process', 'coro_unittest'],
+    install_requires = ['cython>=0.12.1', 'pyrex>=0.9.8.6'],
     cmdclass={'build_ext': build_ext},
 )


### PR DESCRIPTION
(Ran into this bug via: http://code.google.com/p/pysam/issues/detail?id=56)
