### PR TITLE
Fix linux poller

### DIFF
--- a/coro/linux_poller.pyx
+++ b/coro/linux_poller.pyx
@@ -210,7 +210,7 @@ cdef public class queue_poller [ object queue_poller_object, type queue_poller_t
             me = the_scheduler._current
             target = me
             self.event_map[ek] = target
-            self.register_event(ek, flags)
+            self._register_event(ek, flags)
 
             return target
 
@@ -220,7 +220,7 @@ cdef public class queue_poller [ object queue_poller_object, type queue_poller_t
     cdef notify_of_close (self, int fd):
         return
 
-    cdef register_event(self, event_key ek, unsigned int flags): 
+    cdef _register_event(self, event_key ek, unsigned int flags): 
         cdef int r
         cdef epoll_event org_e
         org_e.data.fd = ek.fd
@@ -257,12 +257,6 @@ cdef public class queue_poller [ object queue_poller_object, type queue_poller_t
         return self._wait_for_with_eof(fd, EPOLLIN)
 
     cdef _wait_for_write (self, int fd):
-        return self._wait_for_with_eof(fd, EPOLLOUT)
-
-    def wait_for_read (self, int fd):
-        return self._wait_for_with_eof(fd, EPOLLIN)
-
-    def wait_for_write (self, int fd):
         return self._wait_for_with_eof(fd, EPOLLOUT)
 
     cdef py_event _wait_for (self, int fd, int events):


### PR DESCRIPTION
The gist of this merge is the following commit: 

https://github.com/halayli/shrapnel/commit/e07c1412c903a40caa1247ac2c1a783bc10fc92b

I'd like to have more eyes on it before I commit.

In short: epoll royally sucks.

The longer version: epoll doesn't allow 2 separate events to be
maintained per fd. If we register an fd for read, and then decide
to register it for write too, the later will overwrite the original
registered read event unless we register READ|WRITE. It seems
harmless but it's not. When we register for READ|WRITE and only
a READ event arrives, we first receive the READ event, and in the
next epoll_wait if a READ + WRITE event occurs we'll receive READ|WRITE
because the original registered event is READ|WRITE. What this means
is that we received READ twice here, once as READ and the second
time when a WRITE & READ occured, READ|WRITE. We were not expecting
the second READ event and w'ell have to ignore it.

This behavior happens because we are not passing EPOLLONESHOT. The
reason we don't want to do this is that the EPOLLONESHOT will get applied
to both events (read + write) when we only need it for one. Ex: If we
register for a READ event, followed by registering WRITE event
READ|WRITE|EPOLLONESHOT this will mean if either of the READ or WRITE
event occurs it will be EPOLLONESHOT and the second event will need
to be registered. I certainly don't want to track such events and
reregister them. Hence I am going with the first solution
by not use EPOLLONESHOT and ignore events I am not expecting.

If only epoll supports fd+event as a key rather than fd only.
